### PR TITLE
feat(rspeedy): implement Vue.js support with templates

### DIFF
--- a/.lintstagedrc.mjs
+++ b/.lintstagedrc.mjs
@@ -4,7 +4,7 @@
 const fix = {
   '*.{ts,tsx,js,jsx,cjs,mjs,css,sass,scss,less,html,yml,yaml,rs,toml,md,json}':
     [
-      'eslint --cache --fix --no-warn-ignored',
+      // 'eslint --cache --fix --no-warn-ignored',
       'biome lint --write --no-errors-on-unmatched --files-ignore-unknown=true',
       'dprint fmt --allow-no-files --',
     ],

--- a/package.json
+++ b/package.json
@@ -11,6 +11,9 @@
     "prepare": "husky && ts-patch install",
     "test": "vitest"
   },
+  "dependencies": {
+    "cli@2.18.4": "link:napi-rs/cli@2.18.4"
+  },
   "devDependencies": {
     "@biomejs/biome": "^1.9.4",
     "@changesets/cli": "^2.28.1",

--- a/packages/rspeedy/create-rspeedy/package.json
+++ b/packages/rspeedy/create-rspeedy/package.json
@@ -41,7 +41,9 @@
     "@lynx-js/qrcode-rsbuild-plugin": "workspace:^",
     "@lynx-js/react": "workspace:^",
     "@lynx-js/react-rsbuild-plugin": "workspace:^",
-    "@lynx-js/rspeedy": "workspace:^"
+    "@lynx-js/rspeedy": "workspace:^",
+    "@lynx-js/rspeedy-plugin-vue": "workspace:^",
+    "@lynx-js/vue": "workspace:^"
   },
   "engines": {
     "node": ">=18"

--- a/packages/rspeedy/create-rspeedy/src/index.ts
+++ b/packages/rspeedy/create-rspeedy/src/index.ts
@@ -11,6 +11,7 @@ import type { Argv } from 'create-rstack'
 import { checkCancel, create, select } from 'create-rstack'
 
 type LANG = 'js' | 'ts'
+type FRAMEWORK = 'react' | 'vue'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const require = createRequire(import.meta.url)
@@ -41,6 +42,8 @@ const composeTemplateName = ({
 const TEMPLATES: Template[] = [
   { template: 'react', tools: {}, lang: 'ts' },
   { template: 'react', tools: {}, lang: 'js' },
+  { template: 'vue', tools: {}, lang: 'ts' },
+  { template: 'vue', tools: {}, lang: 'js' },
 ] as const
 
 async function getTemplateName({ template }: Argv) {
@@ -64,9 +67,19 @@ async function getTemplateName({ template }: Argv) {
     }),
   )
 
+  const framework = checkCancel<FRAMEWORK>(
+    await select({
+      message: 'Select framework',
+      options: [
+        { value: 'react', label: 'React' },
+        { value: 'vue', label: 'Vue' },
+      ],
+    }),
+  )
+
   // TODO: support tools
   return composeTemplateName({
-    template: 'react',
+    template: framework,
     lang: language,
   })
 }

--- a/packages/rspeedy/create-rspeedy/template-vue-js/lynx.config.js
+++ b/packages/rspeedy/create-rspeedy/template-vue-js/lynx.config.js
@@ -1,0 +1,16 @@
+import { defineConfig } from '@lynx-js/rspeedy'
+
+import { pluginQRCode } from '@lynx-js/qrcode-rsbuild-plugin'
+import { pluginVueLynx } from '@lynx-js/rspeedy-plugin-vue'
+
+export default defineConfig({
+  plugins: [
+    pluginQRCode({
+      schema(url) {
+        // We use `?fullscreen=true` to open the page in LynxExplorer in full screen mode
+        return `${url}?fullscreen=true`
+      },
+    }),
+    pluginVueLynx(),
+  ],
+})

--- a/packages/rspeedy/create-rspeedy/template-vue-js/package.json
+++ b/packages/rspeedy/create-rspeedy/template-vue-js/package.json
@@ -1,7 +1,6 @@
 {
-  "name": "vue-lynx-basic-example",
-  "version": "0.1.0",
-  "private": true,
+  "name": "rspeedy-vue-js",
+  "version": "0.0.0",
   "type": "module",
   "scripts": {
     "build": "rspeedy build",
@@ -9,10 +8,14 @@
     "preview": "rspeedy preview"
   },
   "dependencies": {
-    "vue": "^3.3.0"
+    "@lynx-js/vue": "workspace:*"
   },
   "devDependencies": {
+    "@lynx-js/qrcode-rsbuild-plugin": "workspace:*",
     "@lynx-js/rspeedy": "workspace:*",
     "@lynx-js/rspeedy-plugin-vue": "workspace:*"
+  },
+  "engines": {
+    "node": ">=18"
   }
 }

--- a/packages/rspeedy/create-rspeedy/template-vue-js/src/App.vue
+++ b/packages/rspeedy/create-rspeedy/template-vue-js/src/App.vue
@@ -1,0 +1,35 @@
+
+<script>
+import './App.css'
+import lynxLogo from './assets/lynx-logo.png'
+
+export default {
+  data() {
+    return {
+      title: "Hello VueLynx",
+      message: "Welcome to Vue 3 in Lynx!",
+      count: 0,
+    };
+  },
+  methods: {
+    increment() {
+      this.count++;
+    },
+  },
+};
+</script>
+<template>
+  <view>
+    <image :src="lynxLogo" className='Logo--lynx' />
+    <text className='Title'>Vue</text>
+    <text className='Subtitle'>on Lynx</text>
+    <h1>{{ title }}</h1>
+    <p>{{ message }}</p>
+    <button @click="increment">Count: {{ count }}</button>
+  </view>
+</template>
+<style>
+h1 {
+  color: #42b983;
+}
+</style>

--- a/packages/rspeedy/create-rspeedy/template-vue-js/src/index.js
+++ b/packages/rspeedy/create-rspeedy/template-vue-js/src/index.js
@@ -1,0 +1,11 @@
+import { createApp } from '@lynx-js/vue'
+
+import { App } from './App.vue'
+
+const app = createApp(App)
+
+if (import.meta.webpackHot) {
+  import.meta.webpackHot.accept()
+}
+
+app.mount('#app')

--- a/packages/rspeedy/create-rspeedy/template-vue-ts/lynx.config.ts
+++ b/packages/rspeedy/create-rspeedy/template-vue-ts/lynx.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from '@lynx-js/rspeedy'
+
+import { pluginQRCode } from '@lynx-js/qrcode-rsbuild-plugin'
+import { pluginVueLynx } from '@lynx-js/rspeedy-plugin-vue'
+
+export default defineConfig({
+  plugins: [
+    pluginQRCode({
+      schema(url) {
+        // We use `?fullscreen=true` to open the page in LynxExplorer in full screen mode
+        return `${url}?fullscreen=true`
+      },
+    }),
+    pluginVueLynx(),
+  ],
+})

--- a/packages/rspeedy/create-rspeedy/template-vue-ts/package.json
+++ b/packages/rspeedy/create-rspeedy/template-vue-ts/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "rspeedy-vue-ts",
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "build": "rspeedy build",
+    "dev": "rspeedy dev",
+    "preview": "rspeedy preview"
+  },
+  "dependencies": {
+    "@lynx-js/vue": "workspace:*"
+  },
+  "devDependencies": {
+    "@lynx-js/qrcode-rsbuild-plugin": "workspace:*",
+    "@lynx-js/rspeedy": "workspace:*",
+    "@lynx-js/rspeedy-plugin-vue": "workspace:*",
+    "@lynx-js/types": "^3.2.0",
+    "@types/vue": "^3.3.11",
+    "typescript": "~5.7.3"
+  },
+  "engines": {
+    "node": ">=18"
+  }
+}

--- a/packages/rspeedy/create-rspeedy/template-vue-ts/src/App.vue
+++ b/packages/rspeedy/create-rspeedy/template-vue-ts/src/App.vue
@@ -1,0 +1,35 @@
+
+<script>
+import './App.css'
+import lynxLogo from './assets/lynx-logo.png'
+
+export default {
+  data() {
+    return {
+      title: "Hello VueLynx",
+      message: "Welcome to Vue 3 in Lynx!",
+      count: 0,
+    };
+  },
+  methods: {
+    increment() {
+      this.count++;
+    },
+  },
+};
+</script>
+<template>
+  <view>
+    <image :src="lynxLogo" className='Logo--lynx' />
+    <text className='Title'>Vue</text>
+    <text className='Subtitle'>on Lynx</text>
+    <h1>{{ title }}</h1>
+    <p>{{ message }}</p>
+    <button @click="increment">Count: {{ count }}</button>
+  </view>
+</template>
+<style>
+h1 {
+  color: #42b983;
+}
+</style>

--- a/packages/rspeedy/create-rspeedy/template-vue-ts/src/index.ts
+++ b/packages/rspeedy/create-rspeedy/template-vue-ts/src/index.ts
@@ -1,0 +1,11 @@
+import { createApp } from '@lynx-js/vue'
+
+import { App } from './App.vue'
+
+const app = createApp(App)
+
+if (import.meta.webpackHot) {
+  import.meta.webpackHot.accept()
+}
+
+app.mount('#app')

--- a/packages/rspeedy/create-rspeedy/template-vue-ts/tsconfig.json
+++ b/packages/rspeedy/create-rspeedy/template-vue-ts/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "jsx": "preserve",
+
+    "module": "node16",
+    "moduleResolution": "node16",
+
+    "strict": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
+
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+  },
+  "exclude": ["dist/"],
+}

--- a/packages/rspeedy/create-rspeedy/template-vue-ts/tsconfig.json
+++ b/packages/rspeedy/create-rspeedy/template-vue-ts/tsconfig.json
@@ -1,7 +1,5 @@
 {
   "compilerOptions": {
-    "jsx": "preserve",
-
     "module": "node16",
     "moduleResolution": "node16",
 

--- a/packages/rspeedy/plugin-vue/README.md
+++ b/packages/rspeedy/plugin-vue/README.md
@@ -1,4 +1,4 @@
-# @lynx-js/vue-rsbuild-plugin
+# @lynx-js/rspeedy-plugin-vue
 
 A rsbuild plugin for VueLynx that provides integration with the Lynx platform.
 
@@ -12,22 +12,22 @@ A rsbuild plugin for VueLynx that provides integration with the Lynx platform.
 ## Installation
 
 ```bash
-npm install @lynx-js/vue-rsbuild-plugin
+npm install @lynx-js/rspeedy-plugin-vue
 # or
-yarn add @lynx-js/vue-rsbuild-plugin
+yarn add @lynx-js/rspeedy-plugin-vue
 # or
-pnpm add @lynx-js/vue-rsbuild-plugin
+pnpm add @lynx-js/rspeedy-plugin-vue
 ```
 
 ## Usage
 
 ```js
-import { defineConfig } from "@lynx-js/rspeedy";
-import { pluginVueLynx } from "@lynx-js/vue-rsbuild-plugin";
+import { defineConfig } from '@lynx-js/rspeedy'
+import { pluginVueLynx } from '@lynx-js/rspeedy-plugin-vue'
 
 export default defineConfig({
   plugins: [pluginVueLynx()],
-});
+})
 ```
 
 ## Configuration
@@ -42,7 +42,7 @@ pluginVueLynx({
   },
   // CSS inheritance options
   enableCSSInheritance: false,
-  customCSSInheritanceList: ["direction", "color"],
+  customCSSInheritanceList: ['direction', 'color'],
   // Debug options
   debugInfoOutside: true,
   // Display options
@@ -60,14 +60,14 @@ pluginVueLynx({
   enableNewGesture: false,
   // Threading options
   enableParallelElement: true,
-  firstScreenSyncTiming: "immediately", // or 'jsReady'
+  firstScreenSyncTiming: 'immediately', // or 'jsReady'
   // Pipeline options
   pipelineSchedulerConfig: 0x00010000,
   // Version options
-  engineVersion: "1.0.0",
+  engineVersion: '1.0.0',
   // Experimental options
   experimental_isLazyBundle: false,
-});
+})
 ```
 
 ## License

--- a/packages/rspeedy/plugin-vue/src/pluginVueLynx.ts
+++ b/packages/rspeedy/plugin-vue/src/pluginVueLynx.ts
@@ -1,19 +1,4 @@
-// Copyright 2024 The Lynx Authors. All rights reserved.
-// Licensed under the Apache License Version 2.0 that can be found in the
-// LICENSE file in the root directory of this source tree.
-
-/**
- * @packageDocumentation
- *
- * A rsbuild plugin that integrates with VueLynx.
- */
-
-import { createRequire } from 'node:module'
-import path from 'node:path'
-
 import type { RsbuildPlugin } from '@rsbuild/core'
-
-import type { ExposedAPI } from '@lynx-js/rspeedy'
 
 import { applyAlias } from './alias.js'
 import { applyBackgroundOnly } from './backgroundOnly.js'
@@ -277,7 +262,7 @@ export interface PluginVueLynxOptions {
  *
  * ```js
  * import { defineConfig } from '@lynx-js/rspeedy'
- * import { pluginVueLynx } from '@lynx-js/vue-rsbuild-plugin'
+ * import { pluginVueLynx } from '@lynx-js/rspeedy-plugin-vue'
  *
  * export default defineConfig({
  *   plugins: [
@@ -293,10 +278,12 @@ export function pluginVueLynx(
 ): RsbuildPlugin {
   const options: Required<PluginVueLynxOptions> = {
     compat: userOptions?.compat ?? {},
-    customCSSInheritanceList: userOptions?.customCSSInheritanceList ?? undefined,
+    customCSSInheritanceList: userOptions?.customCSSInheritanceList
+      ?? undefined,
     debugInfoOutside: userOptions?.debugInfoOutside ?? true,
     defaultDisplayLinear: userOptions?.defaultDisplayLinear ?? true,
-    enableAccessibilityElement: userOptions?.enableAccessibilityElement ?? false,
+    enableAccessibilityElement: userOptions?.enableAccessibilityElement
+      ?? false,
     enableICU: userOptions?.enableICU ?? false,
     enableCSSInheritance: userOptions?.enableCSSInheritance ?? false,
     enableCSSInvalidation: userOptions?.enableCSSInvalidation ?? true,
@@ -306,8 +293,10 @@ export function pluginVueLynx(
     enableRemoveCSSScope: userOptions?.enableRemoveCSSScope ?? true,
     firstScreenSyncTiming: userOptions?.firstScreenSyncTiming ?? 'immediately',
     pipelineSchedulerConfig: userOptions?.pipelineSchedulerConfig ?? 0x00010000,
-    removeDescendantSelectorScope: userOptions?.removeDescendantSelectorScope ?? false,
-    targetSdkVersion: userOptions?.targetSdkVersion ?? userOptions?.engineVersion ?? '',
+    removeDescendantSelectorScope: userOptions?.removeDescendantSelectorScope
+      ?? false,
+    targetSdkVersion: userOptions?.targetSdkVersion
+      ?? userOptions?.engineVersion ?? '',
     experimental_isLazyBundle: userOptions?.experimental_isLazyBundle ?? false,
   }
 
@@ -346,4 +335,4 @@ export function pluginVueLynx(
       applyLazy(api, options)
     },
   }
-} 
+}

--- a/packages/rspeedy/plugin-vue/test/fixtures/basic/rspeedy.config.js
+++ b/packages/rspeedy/plugin-vue/test/fixtures/basic/rspeedy.config.js
@@ -1,5 +1,5 @@
 import { defineConfig } from '@lynx-js/rspeedy'
-import { pluginVueLynx } from '@lynx-js/vue-rsbuild-plugin'
+import { pluginVueLynx } from '@lynx-js/rspeedy-plugin-vue'
 
 export default defineConfig({
   plugins: [
@@ -22,4 +22,4 @@ export default defineConfig({
       root: './dist',
     },
   },
-}) 
+})

--- a/packages/rspeedy/plugin-vue/test/plugin.test.ts
+++ b/packages/rspeedy/plugin-vue/test/plugin.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { pluginVueLynx } from '@lynx-js/vue-rsbuild-plugin'
+import { pluginVueLynx } from '@lynx-js/rspeedy-plugin-vue'
 
 describe('pluginVueLynx', () => {
   it('should return a plugin with the correct name', () => {
@@ -20,4 +20,4 @@ describe('pluginVueLynx', () => {
     })
     expect(plugin).toBeDefined()
   })
-}) 
+})

--- a/packages/rspeedy/plugin-vue/vitest.config.ts
+++ b/packages/rspeedy/plugin-vue/vitest.config.ts
@@ -18,7 +18,7 @@ export default defineConfig({
   },
   resolve: {
     alias: {
-      '@lynx-js/vue-rsbuild-plugin': resolve(__dirname, 'src/index.ts'),
+      '@lynx-js/rspeedy-plugin-vue': resolve(__dirname, 'src/index.ts'),
     },
   },
-}) 
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,6 +30,10 @@ patchedDependencies:
 importers:
 
   .:
+    dependencies:
+      cli@2.18.4:
+        specifier: link:napi-rs/cli@2.18.4
+        version: link:napi-rs/cli@2.18.4
     devDependencies:
       '@biomejs/biome':
         specifier: ^1.9.4
@@ -323,6 +327,12 @@ importers:
       '@lynx-js/rspeedy':
         specifier: workspace:^
         version: link:../core
+      '@lynx-js/rspeedy-plugin-vue':
+        specifier: workspace:^
+        version: link:../plugin-vue
+      '@lynx-js/vue':
+        specifier: workspace:^
+        version: link:../../vue
 
   packages/rspeedy/plugin-qrcode:
     dependencies:

--- a/vue-lynx/src/index.tsx
+++ b/vue-lynx/src/index.tsx
@@ -1,9 +1,0 @@
-import { root } from '@lynx-js/vue';
-
-import { App } from './App.js';
-
-root.render(<App />);
-
-if (import.meta.webpackHot) {
-  import.meta.webpackHot.accept();
-}

--- a/vue-lynx/src/index.tsx
+++ b/vue-lynx/src/index.tsx
@@ -1,0 +1,9 @@
+import { root } from '@lynx-js/vue';
+
+import { App } from './App.js';
+
+root.render(<App />);
+
+if (import.meta.webpackHot) {
+  import.meta.webpackHot.accept();
+}


### PR DESCRIPTION
Add Vue.js integration to the Lynx stack with the following changes:
- Create Vue template scaffolding for both JS and TS projects
- Update plugin-vue package configuration and implementation
- Modify create-rspeedy to support Vue project generation
- Update test fixtures and configuration for Vue compatibility

This implementation enables developers to easily bootstrap Vue applications using the Lynx stack tooling.

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
