### PR TITLE
fix: vitest-setup export path fix to be able to run the tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "test": "vitest"
   },
   "dependencies": {
-    "cli@2.18.4": "link:napi-rs/cli@2.18.4"
+    "cli@2.18.4": "link:napi-rs/cli@2.18.4",
+    "vue": "^3.5.13"
   },
   "devDependencies": {
     "@biomejs/biome": "^1.9.4",

--- a/packages/tools/vitest-setup/package.json
+++ b/packages/tools/vitest-setup/package.json
@@ -14,8 +14,8 @@
     "email": "colinwang.0616@gmail.com"
   },
   "type": "module",
-  "main": "index.ts",
-  "types": "index.ts",
+  "main": "setup.ts",
+  "types": "setup.ts",
   "devDependencies": {
     "path-serializer": "^0.3.4",
     "vitest": "^3.0.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -52,6 +52,9 @@ importers:
       cli@2.18.4:
         specifier: link:napi-rs/cli@2.18.4
         version: link:napi-rs/cli@2.18.4
+      vue:
+        specifier: ^3.5.13
+        version: 3.5.13(typescript@5.7.3)
     devDependencies:
       '@biomejs/biome':
         specifier: ^1.9.4
@@ -9560,14 +9563,6 @@ snapshots:
       chai: 5.2.0
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.0.8(vite@5.4.2(@types/node@20.17.24)(sass-embedded@1.85.0)(terser@5.31.6))':
-    dependencies:
-      '@vitest/spy': 3.0.8
-      estree-walker: 3.0.3
-      magic-string: 0.30.17
-    optionalDependencies:
-      vite: 5.4.2(@types/node@20.17.24)(sass-embedded@1.85.0)(terser@5.31.6)
-
   '@vitest/mocker@3.0.8(vite@5.4.2(@types/node@22.13.5)(sass-embedded@1.85.0)(terser@5.31.6))':
     dependencies:
       '@vitest/spy': 3.0.8
@@ -14109,7 +14104,7 @@ snapshots:
   vitest@3.0.8(@types/debug@4.1.12)(@types/node@20.17.24)(@vitest/ui@3.0.8)(jsdom@26.0.0)(sass-embedded@1.85.0)(terser@5.31.6):
     dependencies:
       '@vitest/expect': 3.0.8
-      '@vitest/mocker': 3.0.8(vite@5.4.2(@types/node@20.17.24)(sass-embedded@1.85.0)(terser@5.31.6))
+      '@vitest/mocker': 3.0.8(vite@5.4.2(@types/node@22.13.5)(sass-embedded@1.85.0)(terser@5.31.6))
       '@vitest/pretty-format': 3.0.8
       '@vitest/runner': 3.0.8
       '@vitest/snapshot': 3.0.8


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/lynx-family/lynx-stack/blob/main/CONTRIBUTING.md.
-->

## Summary

I am not sure this is the good first path. But wanted to run the test locally and analyze the test to understand the code. It was failing because the vitest setup path doesnt seems to be good.

With that it fixes the tests

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
