### PR TITLE
fix rspack catalog in vue-webpack-plugin

### DIFF
--- a/packages/webpack/vue-webpack-plugin/package.json
+++ b/packages/webpack/vue-webpack-plugin/package.json
@@ -44,7 +44,7 @@
     "@lynx-js/css-extract-webpack-plugin": "workspace:*",
     "@lynx-js/template-webpack-plugin": "workspace:*",
     "@microsoft/api-extractor": "catalog:",
-    "@rspack/core": "catalog:",
+    "@rspack/core": "catalog:rspack",
     "css-loader": "^7.1.2",
     "swc-loader": "^0.2.6",
     "vue": "^3.5",


### PR DESCRIPTION
Correctly scope rspack catalog in vue-webpack-plugin package so it can build correctly.