### PR TITLE
Fix broken `main.lynx.bundle`

### DIFF
--- a/packages/rspeedy/plugin-vue/src/pluginVueLynx.ts
+++ b/packages/rspeedy/plugin-vue/src/pluginVueLynx.ts
@@ -1,4 +1,4 @@
-// Copyright 2024 The Lynx Authors. All rights reserved.
+// Copyright 2025 The Lynx Authors. All rights reserved.
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 import type { RsbuildPlugin } from '@rsbuild/core'
@@ -295,9 +295,9 @@ export function pluginVueLynx(
     pipelineSchedulerConfig: userOptions?.pipelineSchedulerConfig ?? 0x00010000,
     removeDescendantSelectorScope: userOptions?.removeDescendantSelectorScope
       ?? false,
-    engineVersion: userOptions?.engineVersion ?? '',
+    engineVersion: userOptions?.engineVersion ?? '3.2',
     targetSdkVersion: userOptions?.targetSdkVersion
-      ?? userOptions?.engineVersion ?? '',
+      ?? userOptions?.engineVersion ?? '3.2',
     experimental_isLazyBundle: userOptions?.experimental_isLazyBundle ?? false,
   }
 


### PR DESCRIPTION
## Summary

Fixes #7

I tried to keep the logic as similar to the React plugin as possible.

- Set default lynx version to 3.2
- Replaced `node:path` import with `createRequire` from `node:module`.
- Changed environment detection from `api.context.command` to `process.env.NODE_ENV`.
- Refactored hot module replacement logic to use `prepend` for development entries.
- Enhanced template filename handling to use regex for replacements.
- Applied encoding plugins conditionally based on the environment.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).


## Further issues

This just fixes the encoding issue in #7 . After visiting the build in LynxExplorer, there are other issues that need to be fixed.